### PR TITLE
remove unneeded useCallback

### DIFF
--- a/src/thunk-reducer.js
+++ b/src/thunk-reducer.js
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 
 /**
  * @callback Thunk
@@ -26,18 +26,18 @@ function useThunkReducer(reducer, initialArg, init = (a) => a) {
   const [hookState, setHookState] = useState(init(initialArg));
 
   const state = useRef(hookState);
-  const getState = useCallback(() => state.current);
-  const setState = useCallback((newState) => {
+  const getState = () => state.current;
+  const setState = (newState) => {
     state.current = newState;
     setHookState(newState);
-  });
+  };
 
-  const reduce = useCallback((action) => reducer(getState(), action));
-  const dispatch = useCallback((action) => (
+  const reduce = (action) => reducer(getState(), action);
+  const dispatch = (action) => (
     typeof action === 'function'
       ? action(dispatch, getState)
       : setState(reduce(action))
-  ));
+  );
 
   return [hookState, dispatch];
 }


### PR DESCRIPTION
I think `useCallback(x)` with no dependency arguments is the same as just `x`, because it will be recomputed every time. At least, that's what I discovered when I tried to compile this as TypeScript: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/4cce72c390b746dd85543b4a8379cf4977582893/types/react/index.d.ts#L961