### PR TITLE
fix: TypeScript types uses default export

### DIFF
--- a/types/thunk-reducer.d.ts
+++ b/types/thunk-reducer.d.ts
@@ -4,4 +4,4 @@ export interface Thunk<S, A> {
   (dispatch: Dispatch<A | Thunk<S, A>>, getState: () => S): void
 }
 
-export function useThunkReducer<S, A>(reducer: Reducer<S, A>, initialArg: S, init?: (s: S) => S): [S, Dispatch<A | Thunk<S, A>>]
+export default function useThunkReducer<S, A>(reducer: Reducer<S, A>, initialArg: S, init?: (s: S) => S): [S, Dispatch<A | Thunk<S, A>>]


### PR DESCRIPTION
typescript was throwing an error...i think because in js the default export is useThunkReducer but in typescript there's no default.