### PR TITLE
update `globalObject` in webpack to support Gatsby SSR

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,6 +11,7 @@ module.exports = {
     libraryTarget: 'umd',
     publicPath: '/dist/',
     umdNamedDefine: true,
+    globalObject: 'typeof self !== "undefined" ? self : this'
   },
   module: {
     rules: [


### PR DESCRIPTION
When attempting to use this library with Gatsby (or any other SSR provider), you will encounter the following error:

```
 ERROR 

There was an error compiling the html.js component for the development server.

See our docs page on debugging HTML builds for help https://gatsby.dev/debug-html ReferenceError: window is not defined


   8 |  else
   9 |          root["react-hook-thunk-reducer"] = factory(root["React"]);
> 10 | })(window, function(__WEBPACK_EXTERNAL_MODULE_react__) {
     |  ^
  11 | return /******/ (function(modules) { // webpackBootstrap
  12 | /******/         // The module cache
  13 | /******/         var installedModules = {};


  WebpackError: ReferenceError: window is not defined
  
  - thunk-reducer.js:10 Object../node_modules/react-hook-thunk-reducer/dist/thunk-reducer.js
    node_modules/react-hook-thunk-reducer/dist/thunk-reducer.js:10:2
  
  - wrap-with-provider.js:1 Module../src/wrap-with-provider.js
    src/wrap-with-provider.js:1:1
  
  - gatsby-ssr.js:1 Module../gatsby-ssr.js
    gatsby-ssr.js:1:1
  
  - unitless.esm.js:31 emit
    node_modules/@emotion/unitless/dist/unitless.esm.js:31:1

```

As of Webpack 4, the default `globalObject` for `umd` builds is `window`, which is undefined on the server in SSR environments. Since this library makes no use of the `window` object, it's actually fine to just set `globalObject` to `null`, but reverting it to Webpack 3 behavior [appears to be the widely accepted solution for compatability](https://github.com/webpack/webpack/issues/6522#issuecomment-371120689).

This doesn't affect the package's function at all, but it does allow it to compile successfully when using SSR.