### PR TITLE
Wrap all local functions inside useCallback

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,2 +1,3 @@
 Nathan Buchar <hello@nathanbuchar.com> (www.nathanbuchar.com)
 Asa Ayers <asa@asaayers.com> (www.asaayers.com)
+Angus Houston <angus.houston@outlook.com.au>

--- a/src/thunk-reducer.js
+++ b/src/thunk-reducer.js
@@ -27,19 +27,16 @@ function useThunkReducer(reducer, initialArg, init = (a) => a) {
 
   // State management.
   const state = useRef(hookState);
-  const getState = () => state.current;
-  const setState = useCallback(
-    (newState) => {
-      state.current = newState;
-      setHookState(newState);
-    },
-    [setHookState]
-  );
+  const getState = useCallback(() => state.current, [state]);
+  const setState = useCallback((newState) => {
+    state.current = newState;
+    setHookState(newState);
+  }, [state, setHookState]);
 
   // Reducer and augmented dispatcher.
   const reduce = useCallback(
     (action) => reducer(getState(), action),
-    [reducer, getState]
+    [reducer, getState],
   );
   const dispatch = useCallback(
     (action) => (
@@ -47,7 +44,7 @@ function useThunkReducer(reducer, initialArg, init = (a) => a) {
         ? action(dispatch, getState)
         : setState(reduce(action))
     ),
-    [dispatch, getState, setState, reduce]
+    [getState, setState, reduce],
   );
 
   return [hookState, dispatch];

--- a/src/thunk-reducer.js
+++ b/src/thunk-reducer.js
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 
 /**
  * @callback Thunk
@@ -28,17 +28,26 @@ function useThunkReducer(reducer, initialArg, init = (a) => a) {
   // State management.
   const state = useRef(hookState);
   const getState = () => state.current;
-  const setState = (newState) => {
-    state.current = newState;
-    setHookState(newState);
-  };
+  const setState = useCallback(
+    (newState) => {
+      state.current = newState;
+      setHookState(newState);
+    },
+    [setHookState]
+  );
 
   // Reducer and augmented dispatcher.
-  const reduce = (action) => reducer(getState(), action);
-  const dispatch = (action) => (
-    typeof action === 'function'
-      ? action(dispatch, getState)
-      : setState(reduce(action))
+  const reduce = useCallback(
+    (action) => reducer(getState(), action),
+    [reducer, getState]
+  );
+  const dispatch = useCallback(
+    (action) => (
+      typeof action === 'function'
+        ? action(dispatch, getState)
+        : setState(reduce(action))
+    ),
+    [dispatch, getState, setState, reduce]
   );
 
   return [hookState, dispatch];

--- a/test/thunk-reducer.spec.js
+++ b/test/thunk-reducer.spec.js
@@ -143,4 +143,61 @@ describe('thunk reducer hook tests', () => {
       expect(dispatch(incrementAndReturnCount())).toEqual(1);
     });
   });
+
+  test('hook result does not change if its inputs are changed', () => {
+    const renderHookResult = renderHook(() => useThunkReducer(reducer, { count: 0 }));
+
+    // Capture the state and dispatch after first render
+    const [state, dispatch] = renderHookResult.result.current;
+
+    // Ensure that the hook state is updated, then rerender the hook
+    renderHookResult
+      .waitForNextUpdate()
+      .then(() => {
+        renderHookResult.rerender();
+      })
+      .then(() => {
+        // Capture the new state and dispatch returned after the hook is
+        // rerendered. This should not change if the hook props are not changed
+        const [newState, newDispatch] = renderHookResult.result.current;
+
+        expect(newState).toBe(state);
+        expect(newDispatch).toBe(dispatch);
+      });
+  });
+
+  test('hook result changes if inputs change', () => {
+    function newReducer(state, { type }) {
+      switch (type) {
+        case 'decrement':
+          return { count: state.count - 1 };
+        default:
+          throw new Error();
+      }
+    }
+
+    const renderHookResult = renderHook(
+      ({ reducerProp }) => useThunkReducer(reducerProp, { count: 0 }),
+      { initialProps: { reducerProp: reducer } },
+    );
+
+    // Capture the state and dispatch after first render
+    const [state, dispatch] = renderHookResult.result.current;
+
+    // Ensure that the hook state is updated, then rerender the hook
+    renderHookResult
+      .waitForNextUpdate()
+      .then(() => {
+        renderHookResult.rerender({ reducerProp: newReducer });
+      })
+      .then(() => {
+        // Capture the new state and dispatch returned after the hook is
+        // rerendered. Because the hook reducer is changed, the returned
+        // dispatch function must also be changed
+        const [newState, newDispatch] = renderHookResult.result.current;
+
+        expect(newState).toBe(state);
+        expect(newDispatch).not.toBe(dispatch);
+      });
+  });
 });


### PR DESCRIPTION
All local variables should be hooked to avoid falsely instantiating identical functions every time the hook is used.

I think this should resolve https://github.com/nathanbuchar/react-hook-thunk-reducer/issues/11