### PR TITLE
release react version restriction

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,8 +48,8 @@
     "webpack-cli": "^3.3.10"
   },
   "peerDependencies": {
-    "react": "^16.8.0",
-    "react-dom": "^16.8.0"
+    "react": ">=16.8.0",
+    "react-dom": ">=16.8.0"
   },
   "files": [
     "AUTHORS",


### PR DESCRIPTION
Now newest react version is 18.0.0,
and many people are using 17.0.x

Perhaps it's better to release version restriction of react.